### PR TITLE
Add simple password protection

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
             text-align: right;
             margin-bottom: 1rem;
         }
-        #printRecipeButton, #saveRecipeChangesButton, #editRecipeButton, #cancelEditButton, #restoreDefaultRecipesButton, #addRecipeButton, #deleteRecipeButton {
+        #printRecipeButton, #saveRecipeChangesButton, #editRecipeButton, #cancelEditButton, #restoreDefaultRecipesButton, #addRecipeButton, #deleteRecipeButton, #changePasswordButton {
              background-color: #2563EB; 
              color: white;
              font-weight: 600; 
@@ -215,7 +215,7 @@
              box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); 
              margin-left: 0.5rem; 
         }
-        #printRecipeButton:hover, #saveRecipeChangesButton:hover, #editRecipeButton:hover, #cancelEditButton:hover, #restoreDefaultRecipesButton:hover, #addRecipeButton:hover, #deleteRecipeButton:hover {
+        #printRecipeButton:hover, #saveRecipeChangesButton:hover, #editRecipeButton:hover, #cancelEditButton:hover, #restoreDefaultRecipesButton:hover, #addRecipeButton:hover, #deleteRecipeButton:hover, #changePasswordButton:hover {
             background-color: #1D4ED8; 
         }
         #editRecipeButton { background-color: #F59E0B; } 
@@ -229,6 +229,8 @@
         #addRecipeButton:hover { background-color: #059669; }
         #deleteRecipeButton { background-color: #DC2626; }
         #deleteRecipeButton:hover { background-color: #B91C1C; }
+        #changePasswordButton { background-color: #0EA5E9; }
+        #changePasswordButton:hover { background-color: #0284C7; }
 
         @media (max-width: 768px) {
             #mobileMenuButton { display: block; position: fixed; top: 1rem; left: 1rem; z-index: 50; background-color: #2563EB; }
@@ -302,6 +304,9 @@
                 </button>
                 <button id="deleteRecipeButton" style="display: none;">
                     🗑️ Excluir Receita
+                </button>
+                <button id="changePasswordButton">
+                    🔑 Definir Senha
                 </button>
             </div>
             <div id="recipeContentContainer" class="content-area p-6 md:p-8">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,14 +18,34 @@ const cancelEditButton = document.getElementById('cancelEditButton');
 const restoreDefaultRecipesButton = document.getElementById('restoreDefaultRecipesButton');
 const addRecipeButton = document.getElementById("addRecipeButton");
 const deleteRecipeButton = document.getElementById("deleteRecipeButton");
+const changePasswordButton = document.getElementById("changePasswordButton");
 
 const flourCalculatorContainer = document.createElement('div');
       flourCalculatorContainer.id = 'flourCalculatorContainer';
       flourCalculatorContainer.classList.add('my-4', 'p-4', 'border', 'border-slate-300', 'rounded-md', 'bg-slate-50', 'no-print'); 
 
 let currentRecipeForSaving = null; 
-let currentRecipeOriginalData = null; 
+let currentRecipeOriginalData = null;
 let isEditMode = false;
+
+function checkPassword() {
+    const stored = localStorage.getItem('apostilaPãesPassword');
+    if (!stored) {
+        const newPass = prompt('Defina uma senha para editar:');
+        if (!newPass) return false;
+        localStorage.setItem('apostilaPãesPassword', newPass);
+        alert('Senha definida.');
+        return true;
+    } else {
+        const entered = prompt('Digite a senha:');
+        if (entered === stored) {
+            return true;
+        } else {
+            alert('Senha incorreta.');
+            return false;
+        }
+    }
+}
 
 function loadDefaultRecipes() {
     defaultBasicRecipesData.forEach(r => r.category = "basicos");
@@ -206,7 +226,8 @@ function addListItem(listElement, type) {
 
 editRecipeButton.addEventListener('click', () => {
     if (currentRecipeForSaving) {
-        currentRecipeOriginalData = JSON.parse(JSON.stringify(currentRecipeForSaving)); 
+        if (!checkPassword()) return;
+        currentRecipeOriginalData = JSON.parse(JSON.stringify(currentRecipeForSaving));
         setEditableState(true);
     }
 });
@@ -628,6 +649,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 document.addEventListener('DOMContentLoaded', () => {
     addRecipeButton.addEventListener('click', () => {
+        if (!checkPassword()) return;
         const name = prompt('Nome da nova receita:');
         if (!name) return;
         const category = prompt('Categoria (basicos, buffet, franceses, avancados):', 'basicos');
@@ -643,6 +665,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     deleteRecipeButton.addEventListener('click', () => {
         if (!currentRecipeForSaving) return;
+        if (!checkPassword()) return;
         if (confirm('Tem certeza que deseja excluir esta receita?')) {
             recipes = recipes.filter(r => !(r.name === currentRecipeForSaving.name && r.category === currentRecipeForSaving.category && r.type !== 'page'));
             saveRecipesToLocalStorage();
@@ -657,6 +680,18 @@ document.addEventListener('DOMContentLoaded', () => {
             addRecipeButton.style.display = 'inline-flex';
             deleteRecipeButton.style.display = 'inline-flex';
             currentRecipeForSaving = null;
+        }
+    });
+
+    changePasswordButton.addEventListener('click', () => {
+        const newPass = prompt('Nova senha (deixe vazio para remover):');
+        if (newPass === null) return;
+        if (newPass === '') {
+            localStorage.removeItem('apostilaPãesPassword');
+            alert('Senha removida.');
+        } else {
+            localStorage.setItem('apostilaPãesPassword', newPass);
+            alert('Senha atualizada.');
         }
     });
 });


### PR DESCRIPTION
## Summary
- prompt for a password when editing, adding or deleting recipes
- allow changing or removing the password via a new button

## Testing
- `python3 -m http.server`
- open the site in the browser
- click **🔑 Definir Senha** to create a password, then try editing a recipe; a password prompt should appear
- ensure add and delete also request the password and that the change password button updates or removes it

------
https://chatgpt.com/codex/tasks/task_e_68414e3056cc8321824eedfeaabfffab