### PR TITLE
Improve main script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,20 @@
         </main>
     </div>
 
-    <script type="module" src="scripts/main.js"></script>
+    <script>
+      (function() {
+        let basePath = location.pathname;
+        if (!basePath.endsWith('/')) {
+          const lastSeg = basePath.substring(basePath.lastIndexOf('/') + 1);
+          basePath = lastSeg.includes('.')
+            ? basePath.substring(0, basePath.lastIndexOf('/') + 1)
+            : basePath + '/';
+        }
+        const script = document.createElement('script');
+        script.type = 'module';
+        script.src = basePath + 'scripts/main.js';
+        document.currentScript.after(script);
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure `main.js` loads from the correct folder even if URL has no trailing slash

## Testing
- `node --check scripts/main.js`
- `curl -I http://localhost:8080/scripts/main.js`
- `curl -I http://localhost:8080/data/recipes.js`


------
https://chatgpt.com/codex/tasks/task_e_6841a2af49bc83219af3ef9715a43a90