### PR TITLE
Fix dynamic script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,12 @@
         </main>
     </div>
 
-    <script type="module" src="scripts/main.js"></script>
+    <script>
+      const base = location.pathname.replace(/[^\/]*$/, '');
+      const s = document.createElement('script');
+      s.type = 'module';
+      s.src = base + 'scripts/main.js';
+      document.currentScript.replaceWith(s);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load main script dynamically so relative paths work without trailing slash

## Testing
- `node --check scripts/main.js`
- `curl -I http://localhost:8000/scripts/main.js`
- `curl -I http://localhost:8000/data/recipes.js`


------
https://chatgpt.com/codex/tasks/task_e_6841a2af49bc83219af3ef9715a43a90